### PR TITLE
Propagate errors from loading styles and locales

### DIFF
--- a/citeproc-wrapper.js
+++ b/citeproc-wrapper.js
@@ -7,11 +7,13 @@ function Citeproc (citations, styleLocation, localeLocation, done) {
     this.construct = function () {
         var self = this;
 
-        self.loadStyle(styleLocation, function () {
-            self.loadLocale(localeLocation, function () {
+        self.loadStyle(styleLocation, function (err) {
+            if (err) return done(err);
+            self.loadLocale(localeLocation, function (err) {
+                if (err) return done(err);
                 self.setupSys();
                 citeproc = new CSL.Engine(sys, style);
-                done(citeproc);
+                done(null, citeproc);
             });
         });
     }

--- a/test/test.js
+++ b/test/test.js
@@ -10,11 +10,35 @@ describe('citeproc-js', function () {
         var style  = './styles/chicago-fullnote-bibliography.csl';
         var locale = './locales/locales-nb-NO.xml';
 
-        var cite = new Citeproc(citations, style, locale, function (citeproc) {
+        var cite = new Citeproc(citations, style, locale, function (err, citeproc) {
+            if(err) done(err);
+
             citeproc.updateItems(Object.keys(citations));
             var bibliography = citeproc.makeBibliography();
             console.log(bibliography);
             done();
+        });
+    });
+    it('should error if an incorrect style used', function (done) {
+        this.timeout(3000);
+
+        var style  = './styles/this-does-not-exist.csl';
+        var locale = './locales/locales-nb-NO.xml';
+
+        var cite = new Citeproc(citations, style, locale, function (err) {
+            if(err) console.log(err);
+            done(!(err instanceof Error));
+        });
+    });
+    it('should error if an incorrect locale used', function (done) {
+        this.timeout(3000);
+
+        var style  = './styles/chicago-fullnote-bibliography.csl';
+        var locale = './locales/this-does-not-exist.xml';
+
+        var cite = new Citeproc(citations, style, locale, function (err) {
+            if(err) console.log(err);
+            done(!(err instanceof Error));
         });
     });
 });


### PR DESCRIPTION
When using the library, you can send whatever style and locale you want - whether they exist or not. If either of these don't exist, then you get errors.

Instead of never checking to see if the callbacks to `loadStyle` and `loadLocale` contain an error, this PR passes them back up the chain so that when you do a `new Citeproc`, the callback has 2 params, an error object and a citeproc object.

```
var cite = new Citeproc(citations, style, locale, function (err, citeproc) {
  if(err) return 'I dont think so!';

  citeproc.updateItems(Object.keys(citations));
  ...
});
```

You can therefore do some rudimentary error checking to see if an error is present and if so, do something about it before you get near making a call to `updateItems` and the rest.

I've added a couple of tests to ensure this behaviour.

This would be a breaking change to the app as you are now returning 2 params instead of just the 1.
