### PR TITLE
validate xml

### DIFF
--- a/src/csl_nodejs_jsdom.js
+++ b/src/csl_nodejs_jsdom.js
@@ -342,7 +342,7 @@ var CSL_NODEJS_JSDOM = function () {
     this.parser = new DOMParser();
     // This seems horribly tormented, but there might be a reason for it.
     // Perhaps this was the only way I found to get namespacing to work ... ?
-    var str = "<docco><institution institution-parts=\"long\" delimiter=\", \" substitute-use-first=\"1\" use-last=\"1\"><institution-part name=\"long\"></institution></docco>";
+    var str = "<docco><institution institution-parts=\"long\" delimiter=\", \" substitute-use-first=\"1\" use-last=\"1\"><institution-part name=\"long\"/></institution></docco>";
     var inst_doc = this.parser.parseFromString(str, "text/xml");
     var inst_node = inst_doc.getElementsByTagName("institution");
     this.institution = inst_node.item(0);


### PR DESCRIPTION
The missing close tag in this XML was giving me a sax.js warning when it tries to parse it.

`
Error: Unexpected close tag
Line: 0
Column: 142
Char: >
    at error (/Users/faunta/dev/test/node_modules/sax/lib/sax.js:667:10)
    at strictFail (/Users/faunta/dev/test/node_modules/sax/lib/sax.js:693:7)
    at closeTag (/Users/faunta/dev/test/node_modules/sax/lib/sax.js:887:9)
    at Object.write (/Users/faunta/dev/test/node_modules/sax/lib/sax.js:1452:13)
    at HtmlToDom._parseWithsax (/Users/faunta/dev/test/node_modules/jsdom/lib/jsdom/browser/htmltodom.js:198:12)
    at HtmlToDom.appendHtmlToDocument (/Users/faunta/dev/test/node_modules/jsdom/lib/jsdom/browser/htmltodom.js:47:48)
    at exports.jsdom (/Users/faunta/dev/test/node_modules/jsdom/lib/jsdom.js:147:31)
    at DOMParser.CSL_NODEJS_JSDOM.DOMParser.parseFromString (/Users/faunta/dev/test/node_modules/citeproc/src/csl_nodejs_jsdom.js:272:23)
    at new CSL_NODEJS_JSDOM (/Users/faunta/dev/test/node_modules/citeproc/src/csl_nodejs_jsdom.js:346:32)
    at new CSL.Engine (/Users/faunta/dev/test/node_modules/citeproc/src/citeproc.js:1284:20)
    at /Users/faunta/dev/test/node_modules/citeproc/citeproc-wrapper.js:13:28
    at /Users/faunta/dev/test/node_modules/citeproc/citeproc-wrapper.js:50:20
    at wrappedCallback 
`