### PR TITLE
PLT 34 Fix Error Deploying with CDK using esbuild in Node 18 environment.

### DIFF
--- a/citeproc-wrapper.js
+++ b/citeproc-wrapper.js
@@ -7,11 +7,13 @@ function Citeproc (citations, styleLocation, localeLocation, done) {
     this.construct = function () {
         var self = this;
 
-        self.loadStyle(styleLocation, function () {
-            self.loadLocale(localeLocation, function () {
+        self.loadStyle(styleLocation, function (err) {
+            if (err) return done(err);
+            self.loadLocale(localeLocation, function (err) {
+                if (err) return done(err);
                 self.setupSys();
                 citeproc = new CSL.Engine(sys, style);
-                done(citeproc);
+                done(null, citeproc);
             });
         });
     }

--- a/test/test.js
+++ b/test/test.js
@@ -10,11 +10,11 @@ describe('citeproc-js', function () {
         var style  = './styles/chicago-fullnote-bibliography.csl';
         var locale = './locales/locales-nb-NO.xml';
 
-        var cite = new Citeproc(citations, style, locale, function (citeproc) {
+        var cite = new Citeproc(citations, style, locale, function (err, citeproc) {
             citeproc.updateItems(Object.keys(citations));
             var bibliography = citeproc.makeBibliography();
             console.log(bibliography);
-            done();
+            done(err);
         });
     });
 });


### PR DESCRIPTION
Deploying this library as a dependancy to run in a lambda, using cdk and esbuild for a Node 18 environment we get the following error.

This doesn't happen during the lambda run when it hits the line - it stops the lambda correctly starting:

![image](https://github.com/michaelmcmillan/citeproc-node-iojs/assets/232529/cbc75155-956a-4d2f-820d-990395295570)

The error is caused by this function:

```
      function composeRegularExpressions() {
        composeParticleLists();
        REX.family = new RegExp("^((?:" + LIST.family.space.join("|") + ")(\\s+)|(?:" + LIST.family.nospace.join("|") + "([^\\s]))).*", "i");
        REX.given.full_comma = new RegExp(".*?(,[\\s]*)(" + LIST.given.full.join("|") + ")$", "i");
        REX.given.full_lower = new RegExp(".*?([ ]+)(" + LIST.given.full.join("|") + ")$");
        X = "Tom du".match(REX.given.full_lower);
        var allInTheFamily = LIST.family.space;
        for (var key2 in LIST.given.partial) {
          REX.given.partial[key2] = new RegExp(".*?(\\s+)(" + LIST.given.partial[key2].join("|") + ")$", "i");
        }
      }
```

## Resolution

Add a `var` to correctly declare the variable.

Testing this fix with: https://github.com/talis/citeproc-cdk-test this change is allowing us to progress and deploy the lambda.